### PR TITLE
Draft/anatomy inner keys

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -113,7 +113,10 @@ class AnatomyDict(dict):
     def __init__(self, in_data, key=None, parent=None, strict=None):
         super(AnatomyDict, self).__init__()
         for _key, _value in in_data.items():
-            if not isinstance(_value, AnatomyResult):
+            if (
+                not isinstance(_value, numbers.Number) and
+                not isinstance(_value, AnatomyResult)
+            ):
                 _value = self.__class__(_value, _key, self)
             self[_key] = _value
 

--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -113,10 +113,7 @@ class AnatomyDict(dict):
     def __init__(self, in_data, key=None, parent=None, strict=None):
         super(AnatomyDict, self).__init__()
         for _key, _value in in_data.items():
-            if (
-                not isinstance(_value, numbers.Number) and
-                not isinstance(_value, AnatomyResult)
-            ):
+            if isinstance(_value, dict):
                 _value = self.__class__(_value, _key, self)
             self[_key] = _value
 
@@ -206,7 +203,10 @@ class AnatomyDict(dict):
                     continue
                 result[key] = value
 
-            elif value.solved:
+            elif (
+                not hasattr(value, "solved") or
+                value.solved
+            ):
                 result[key] = value
         return self.__class__(result, key=self.key, parent=self.parent)
 

--- a/tests/test_anatomy.py
+++ b/tests/test_anatomy.py
@@ -21,20 +21,12 @@ valid_data = {
 }
 
 solve_templates = {
-    "resources": {
-        "footage": "{root[resources]}/{nonExistent}/resources/footage"
-    },
-    "work": {
-        "file": "{project[code]}_{asset}_{task}_v{version:0>3}<_{comment}>.{ext}",
-        "file2": "{project[code]}_{asset}_{task}_v{version:0>3}<_{nocomment}>.{ext}",
-        "noDictKey": "{project[code]}_{asset[name]}_{task}_v{version:0>3}<_{nocomment}>.{ext}",
-        "path": "{root[work]}/{projaect[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/v{version:0>3}/{project[code]}_{asset}_{subset}_v{version:0>3}.{representation}",
+    "basic": {
+        "comment": "{asset}_{task}_v{version:0>3}<_{comment}>.{ext}",
+        "nocomment": "{asset}_{task}_v{version:0>3}<_{nocomment}>.{ext}",
+        "noDictKey": "{project[code]}_{asset[name]}_v{version:0>3}.{ext}",
+        "noDictKey": "{project[code]}_{asset[name]}_v{version:0>3}.{ext}",
         "multiple_optional": "{project[code]}</{asset}></{hierarchy}><_v{version:0>3}><_{nocomment}>.{ext}"
-    },
-    "avalon": {
-        "workfile": "{asset}_{task}_v{version:0>3}<_{comment}>",
-        "work": "{root}/{project[name]}/{hierarchy}/{asset}/work/{task}",
-        "publish": "{root}/{project[name]}/{hierarchy}/{asset}/publish/{family}/{subset}/v{version:0>3}/{project[code]}_{asset}_{subset}_v{version:0>3}.{representation}"
     }
 }
 
@@ -42,13 +34,20 @@ features_templates = {
     "version_padding": 3,
     "version": "v{version:0>{@version_padding}}",
     "inner_keys": {
-        "folder": "{root[work]}/{project[name]}/{hierarchy}/{asset}/publish/{@version}",
-        "file": "{project[code]}_{asset}_{task}_v{version:0>3}<_{comment}>.{ext}",
+        "folder": "{project[name]}/{hierarchy}/{asset}/{@version}",
+        "file": "{project[code]}_{asset}_v{version:0>3}.{ext}",
+        "path": "{@folder}/{@file}"
+    },
+    "inner_override": {
+        "version_padding": 2,
+        "version": "ver{version:0>{@version_padding}}",
+        "folder": "{hierarchy}/{asset}/{@version}",
+        "file": "{project[code]}_{asset}_{@version}.{ext}",
         "path": "{@folder}/{@file}"
     },
     "missing_keys": {
         "missing_1": "{missing_key}/{project[code]}_{asset}",
-        "missing_2": "{project[code]}_{missing_key1}_{asset}_{task}_v{version:0>3}<_{comment}>.{ext}{missing_key2}"
+        "missing_2": "{missing_key1}_{asset}<_{comment}>.{ext}{missing_key2}"
     },
     "invalid_types": {
         "invalid_type": "{project}_{asset[name]}"
@@ -80,14 +79,14 @@ def test_format_anatomy():
     anatomy = Anatomy()
     solved = anatomy.solve_dict(solve_templates, valid_data)
 
-    assert solved['work']['file2'] == "PRJ_BOB_MODELING_v001.ABC"
-    assert solved['work']['file'] == "PRJ_BOB_MODELING_v001_iAmComment.ABC"
+    assert solved['basic']['comment'] == "BOB_MODELING_v001_iAmComment.ABC"
+    assert solved['basic']['nocomment'] == "BOB_MODELING_v001.ABC"
 
-    assert solved['work']['noDictKey'] == "PRJ_{asset[name]}_MODELING_v001.ABC"
+    assert solved['basic']['noDictKey'] == "PRJ_{asset[name]}_v001.ABC"
 
 
 def test_anatomy(anatomy_file, monkeypatch):
-    # TODO add test for `missing_keys` and `invalid_types`
+    # TODO add test for `invalid_types`
     anatomy_file = os.path.join(anatomy_file, "repos", "pype-config")
     print(anatomy_file)
 
@@ -97,26 +96,35 @@ def test_anatomy(anatomy_file, monkeypatch):
     filled_all = anatomy.format_all(valid_data)
     filled = anatomy.format(valid_data)
 
-    assert filled_all['work']['file'] == "PRJ_BOB_MODELING_v001_iAmComment.ABC"
-    assert filled_all['work']['file2'] == "PRJ_BOB_MODELING_v001.ABC"
-    assert filled_all['work']['noDictKey'] == "PRJ_{asset[name]}_MODELING_v001.ABC"
+    assert filled_all['basic']['comment'] == "BOB_MODELING_v001_iAmComment.ABC"
+    assert filled_all['basic']['nocomment'] == "BOB_MODELING_v001.ABC"
+    assert filled_all['basic']['noDictKey'] == "PRJ_{asset[name]}_v001.ABC"
 
-    assert filled_all['missing_keys']['missing_1'].missing_keys == ["missing_key"]
-    assert sorted(filled_all['missing_keys']['missing_2'].missing_keys) == ["missing_key1", "missing_key2"]
+    missing_1 = filled_all['missing_keys']['missing_1'].missing_keys
+    assert missing_1 == ["missing_key"]
+
+    missing_2 = sorted(filled_all['missing_keys']['missing_2'].missing_keys)
+    assert missing_2 == ["missing_key1", "missing_key2"]
 
     assert filled_all["invalid_types"]["invalid_type"].invalid_types == {
         "project": dict,
         "asset": str
     }
 
-    assert filled['work']['file'] == "PRJ_BOB_MODELING_v001_iAmComment.ABC"
-    assert filled['work']['file2'] == "PRJ_BOB_MODELING_v001.ABC"
-    assert filled['work']['multiple_optional'] == "PRJ/BOB/asset/characters_v001.ABC"
+    assert filled['basic']['comment'] == "BOB_MODELING_v001_iAmComment.ABC"
+    assert filled['basic']['nocomment'] == "BOB_MODELING_v001.ABC"
+    assert filled['basic']['multiple_optional'] == "PRJ/BOB/asset/characters_v001.ABC"
 
     try:
-        filled_all['work']['noDictKey']
+        filled_all['basic']['noDictKey']
         raise AssertionError("Should raise error about missing key")
     except Exception:
         pass
 
-    assert filled["inner_keys"]["path"] == "\\volume\\projects/P001_ProjectX/asset/characters/BOB/publish/v001/PRJ_BOB_MODELING_v001_iAmComment.ABC"
+    inner_path = "P001_ProjectX/asset/characters/BOB/v001/PRJ_BOB_v001.ABC"
+    assert filled["inner_keys"]["path"] == inner_path
+
+    inner_override_file = "PRJ_BOB_ver01.ABC"
+    assert filled["inner_override"]["file"] == inner_override_file
+
+    inner_path = "P001_ProjectX/asset/characters/BOB/v001/PRJ_BOB_ver01.ABC"

--- a/tests/test_anatomy.py
+++ b/tests/test_anatomy.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from pypeapp import Anatomy
+from pypeapp.lib.anatomy import Anatomy, AnatomyUnsolved
 import ruamel.yaml as yaml
 
 
@@ -94,21 +94,31 @@ def test_anatomy(anatomy_file, monkeypatch):
     filled_all = anatomy.format_all(valid_data)
     filled = anatomy.format(valid_data)
 
+    # Basic tests
     assert filled_all['basic']['comment'] == "BOB_MODELING_v001_iAmComment.ABC"
     assert filled_all['basic']['nocomment'] == "BOB_MODELING_v001.ABC"
     assert filled_all['basic']['noDictKey'] == "PRJ_{asset[name]}_v001.ABC"
 
+    # Missing keys
     missing_1 = filled_all['missing_keys']['missing_1'].missing_keys
     assert missing_1 == ["missing_key"]
 
     missing_2 = sorted(filled_all['missing_keys']['missing_2'].missing_keys)
     assert missing_2 == ["missing_key1", "missing_key2"]
 
+    try:
+        filled['missing_keys']['missing_1']
+        raise AssertionError("Should raise error about missing key")
+    except AnatomyUnsolved:
+        pass
+
+    # Invalid types
     assert filled_all["invalid_types"]["invalid_type"].invalid_types == {
         "project": dict,
         "asset": str
     }
 
+    # Inner keys
     inner_path = "P001_ProjectX/asset/characters/BOB/v001/PRJ_BOB_v001.ABC"
     assert filled["inner_keys"]["path"] == inner_path
 

--- a/tests/test_anatomy.py
+++ b/tests/test_anatomy.py
@@ -25,7 +25,6 @@ solve_templates = {
         "comment": "{asset}_{task}_v{version:0>3}<_{comment}>.{ext}",
         "nocomment": "{asset}_{task}_v{version:0>3}<_{nocomment}>.{ext}",
         "noDictKey": "{project[code]}_{asset[name]}_v{version:0>3}.{ext}",
-        "noDictKey": "{project[code]}_{asset[name]}_v{version:0>3}.{ext}",
         "multiple_optional": "{project[code]}</{asset}></{hierarchy}><_v{version:0>3}><_{nocomment}>.{ext}"
     }
 }
@@ -86,7 +85,6 @@ def test_format_anatomy():
 
 
 def test_anatomy(anatomy_file, monkeypatch):
-    # TODO add test for `invalid_types`
     anatomy_file = os.path.join(anatomy_file, "repos", "pype-config")
     print(anatomy_file)
 
@@ -111,20 +109,8 @@ def test_anatomy(anatomy_file, monkeypatch):
         "asset": str
     }
 
-    assert filled['basic']['comment'] == "BOB_MODELING_v001_iAmComment.ABC"
-    assert filled['basic']['nocomment'] == "BOB_MODELING_v001.ABC"
-    assert filled['basic']['multiple_optional'] == "PRJ/BOB/asset/characters_v001.ABC"
-
-    try:
-        filled_all['basic']['noDictKey']
-        raise AssertionError("Should raise error about missing key")
-    except Exception:
-        pass
-
     inner_path = "P001_ProjectX/asset/characters/BOB/v001/PRJ_BOB_v001.ABC"
     assert filled["inner_keys"]["path"] == inner_path
 
     inner_override_file = "PRJ_BOB_ver01.ABC"
     assert filled["inner_override"]["file"] == inner_override_file
-
-    inner_path = "P001_ProjectX/asset/characters/BOB/v001/PRJ_BOB_ver01.ABC"


### PR DESCRIPTION
**Changes:**

- Anatomy templates can use it’s global and inner keys in templates
- It is allowed to use only keys from same group of templates
- global keys are added to each group but can be changed per template group

**Example:**
```
version_padding: 3
version: "v{version:0>{@version_padding}}"

example_1:
  file: "{@version}.{representation}"
  folder: "{root}"
  path: "{@folder}/{@file}"

example_2:
  version_padding: 4
  file: "{@version}.{representation}"
  folder: "{root}"
  path: "{@folder}/{@file}"
```
Result in `Anatomy.templates`:
```
version_padding: 3
version: "v{version:0>{@version_padding}}"

example_1:
  file: "v{version:0>3.{representation}"
  folder: "{root}"
  path: "{root}/v{version:0>3.{representation}"

example_2:
  version_padding: 4
  file: "v{version:0>4.{representation}.{representation}"
  folder: "{root}"
  path: "{root}/v{version:0>4.{representation}.{representation}"
```
IMPORTANT: It is not allowed to use keys from example_1 inside example_2

**Possible change:**

We should probably be more specific about how to set global keys. Something like:
```
global_keys:
  version_padding: 3
  version: "v{version:0>{@version_padding}}"
```

Please give me commentary about this solution…