### PR TITLE
Hotfix/fix selecting pytest test

### DIFF
--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -436,8 +436,8 @@ class PypeLauncher(object):
                                      'repos', 'pype', 'pype', 'tests'))
 
         elif id:
-            t.echo("  - selecting test ID [ {} ]".format(id))
-            args.append(id)
+            t.echo("  - selecting test ID [ {} ]".format(id[0]))
+            args.append(id[0])
         else:
             args.append(os.path.join(os.getenv('PYPE_ROOT'),
                                      'repos', 'pype', 'pype', 'tests'))

--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -464,8 +464,8 @@ class PypeLauncher(object):
             args.append(os.path.join(os.getenv('PYPE_ROOT'), 'tests'))
 
         elif id:
-            t.echo("  - selecting test ID [ {} ]".format(id))
-            args.append(id)
+            t.echo("  - selecting test ID [ {} ]".format(id[0]))
+            args.append(id[0])
         else:
             args.append(os.path.join(os.getenv('PYPE_ROOT'), 'tests'))
 


### PR DESCRIPTION
This simple fix is fixing ability to select test ids for py test:
```
pype test tests/test_storage.py::TestStorage::test_read_storage_file
```