### PR TITLE
Custom python interpreter option

### DIFF
--- a/pype
+++ b/pype
@@ -661,9 +661,11 @@ main () {
   fi
 
   echo -e "${IGreen}>>>${RST} Running ${IWhite}Pype${RST} ..."
-  $PYTHON -m pypeapp $args
+  $PYTHON -m pypeapp $args || return $?
   echo -e "${IPurple}xxx${RST} Finishing up. ${IWhite}Have a nice day!${RST}"
 }
 
-main "$args"
+return_code=0
+main "$args" || return_code=$?
 deactivate_venv $PYPE_ENV
+exit $return_code

--- a/pype
+++ b/pype
@@ -123,6 +123,8 @@ if [[ -z $PYPE_LOG_NO_COLORS ]]; then
   source "$PYPE_ROOT/pypeapp/colors.sh"
 fi
 
+
+
 ###############################################################################
 # Display spinner for running job. Job must be running in a background.
 # Usage:
@@ -406,28 +408,45 @@ detect_mongo () {
 #   None
 ###############################################################################
 detect_python () {
-  echo -e "${BIGreen}>>>${RST} looking for ${BIWhite}[ python ]${RST} ... \c"
-  command -v $PYTHON >/dev/null 2>&1 || { echo -e "${BIRed}FAILED${RST}"; return 1; }
-  # Parse version string
-  local version_command="import sys;print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))"
-  local python_version="$($PYTHON <<< ${version_command})"
-  oIFS="$IFS"
-  IFS=.
-  set -- $python_version
-  IFS="$oIFS"
-  if [ "$1" -ge "3" ] && [ "$2" -ge "6" ] ; then
-    echo -e "${BIGreen}$1.$2${RST}"
-  else
-    # Python is old, but maybe we have newer just not symlinked to `python`
-    PYTHON="python3.6"
-    command -v $PYTHON >/dev/null 2>&1 || { echo -e "${BIRed}FAILED${RST} ${BIYellow} Version [${RST}${BICyan}$1.$2${RST}]${BIYellow} is old and unsupported${RST}"; return 1; }
-    # If so, change python interpreter name
+  # override Python interpreter if needed
+  if [[ -z $PYPE_PYTHON_EXE ]]; then
+    echo -e "${BIGreen}>>>${RST} looking for ${BIWhite}[ python ]${RST} ... \c"
+    command -v $PYTHON >/dev/null 2>&1 || { echo -e "${BIRed}FAILED${RST}"; return 1; }
+    # Parse version string
+    local version_command="import sys;print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))"
     local python_version="$($PYTHON <<< ${version_command})"
     oIFS="$IFS"
     IFS=.
     set -- $python_version
     IFS="$oIFS"
-    echo -e "${BIGreen}$1.$2${RST}"
+    if [ "$1" -ge "3" ] && [ "$2" -ge "6" ] ; then
+      echo -e "${BIGreen}$1.$2${RST}"
+    else
+      # Python is old, but maybe we have newer just not symlinked to `python`
+      PYTHON="python3.6"
+      command -v $PYTHON >/dev/null 2>&1 || { echo -e "${BIRed}FAILED${RST} ${BIYellow} Version [${RST}${BICyan}$1.$2${RST}]${BIYellow} is old and unsupported${RST}"; return 1; }
+      # If so, change python interpreter name
+      local python_version="$($PYTHON <<< ${version_command})"
+      oIFS="$IFS"
+      IFS=.
+      set -- $python_version
+      IFS="$oIFS"
+      echo -e "${BIGreen}$1.$2${RST}"
+    fi
+  else
+    echo -e "${BIYellow}>>>${RST} Forced using python at [ ${BIWhite}[ $PYPE_PYTHON_EXE ]${RST} ... \c"
+    local version_command="import sys;print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))"
+    local python_version="$($PYPE_PYTHON_EXE <<< ${version_command})"
+    oIFS="$IFS"
+    IFS=.
+    set -- $python_version
+    IFS="$oIFS"
+    if [ "$1" -ge "3" ] && [ "$2" -ge "6" ] ; then
+      echo -e "${BIGreen}$1.$2${RST}"
+      PYTHON=$PYPE_PYTHON_EXE
+    else
+      command -v $PYPE_PYTHON_EXE >/dev/null 2>&1 || { echo -e "${BIRed}FAILED${RST} ${BIYellow} Version [${RST}${BICyan}$1.$2${RST}]${BIYellow} is old and unsupported${RST}"; return 1; }
+    fi
   fi
 }
 

--- a/pype.ps1
+++ b/pype.ps1
@@ -460,9 +460,9 @@ function Detect-Mongo {
 
 
 function Detect-Python {
-  if (Test-Path 'env:PYPE_PYTHON_EXE') {
-    Log-Msg -Text ">>> ", "Forced using python at [ ", $env:PYPE_PYTHON_EXE ," ] ... " -Color Yellow, Gray, White, Gray -NoNewLine
-    $python = $env:PYPE_PYTHON_EXE
+  if (Test-Path "$($env:PYPE_PYTHON_EXE)") {
+    Log-Msg -Text ">>> ", "Forced using python at [ ", "$($env:PYPE_PYTHON_EXE)" ," ] ... " -Color Yellow, Gray, White, Gray -NoNewLine
+    $python = "$($env:PYPE_PYTHON_EXE)"
   } else {
     Log-Msg -Text ">>> ", "Detecting python ... " -Color Green, Gray -NoNewLine
     if (-not (Get-Command "python" -ErrorAction SilentlyContinue)) {

--- a/pype.ps1
+++ b/pype.ps1
@@ -62,6 +62,7 @@ $art = @'
 # .
 
 $arguments=$ARGS
+$python="python"
 $traydebug=$false
 $venv_activated=$false
 # map double hyphens to single for powershell use
@@ -99,11 +100,6 @@ if($arguments -eq "clean") {
 
 # -----------------------------------------------------------------------------
 # Initialize important environment variables
-
-# override Python interpreter if needed
-if (-not (Test-Path 'env:PYPE_PYTHON_EXE')) {
-  $env:PYPE_PYTHON_EXE = "python"
-}
 
 # set PYPE_ROOT to current directory.
 if (-not (Test-Path 'env:PYPE_ROOT')) {
@@ -284,14 +280,14 @@ function Update-Requirements {
 
 function Install-Environment {
   if($help -eq $true) {
-    & $env:PYPE_PYTHON_EXE -m "pypeapp" install --help
+    & $python -m "pypeapp" install --help
     ExitWithCode 0
   }
   Log-Msg -Text ">>> ", "Installing environment to [ ", $env:PYPE_ENV, " ]" -Color Green, Gray, White, Gray
   if($force -eq $true) {
-      & $env:PYPE_PYTHON_EXE -m "pypeapp" install --force
+      & $python -m "pypeapp" install --force
   } else {
-      & $env:PYPE_PYTHON_EXE -m "pypeapp" install
+      & $python -m "pypeapp" install
   }
   if ($LASTEXITCODE -ne 0) {
     Log-Msg -Text "!!! ", "Installation failed (", $LASTEXITCODE, ")" -Color Red, Yellow, Magenta, Yellow
@@ -308,7 +304,7 @@ function Install-Environment {
 function Check-Environment {
   # get current pip environment
   Log-Msg -Text ">>> ", "Validating environment dependencies ... " -Color Green, Gray -NoNewLine
-  & $env:PYPE_PYTHON_EXE "$($env:PYPE_ROOT)\pypeapp\requirements.py"
+  & $python "$($env:PYPE_ROOT)\pypeapp\requirements.py"
   # get requirements file
   if ($LASTEXITCODE -ne 0) {
     # environment differs from requirements.txt
@@ -342,7 +338,7 @@ function Upgrade-pip {
   {
     Log-Msg -Text ">>> ", "Updating pip ... " -Color Green, Gray -NoNewLine
     Start-Progress {
-      & $env:PYPE_PYTHON_EXE -m pip install --upgrade pip | out-null
+      & $python -m pip install --upgrade pip | out-null
     }
     Write-Host ""
   }
@@ -391,14 +387,14 @@ function Deploy-Pype {
   )
   # process pype deployment
   if ($help -eq $true) {
-    & $env:PYPE_PYTHON_EXE -m "pypeapp" deploy --help
+    & $python -m "pypeapp" deploy --help
     Deactivate-Venv
     ExitWithCode 0
   }
   if ($Force -eq $true) {
-    & $env:PYPE_PYTHON_EXE -m "pypeapp" deploy --force
+    & $python -m "pypeapp" deploy --force
   } else {
-    & $env:PYPE_PYTHON_EXE -m "pypeapp" deploy
+    & $python -m "pypeapp" deploy
   }
   <#
   .SYNOPSIS
@@ -412,11 +408,11 @@ function Deploy-Pype {
 
 function Validate-Pype {
   if ($help -eq $true) {
-      & $env:PYPE_PYTHON_EXE -m "pypeapp" validate --help
+      & $python -m "pypeapp" validate --help
       Deactivate-Venv
       ExitWithCode 0
   }
-  & $env:PYPE_PYTHON_EXE -m "pypeapp" validate
+  & $python -m "pypeapp" validate
   <#
   .SYNOPSIS
   This will validate pype deployment
@@ -464,8 +460,9 @@ function Detect-Mongo {
 
 
 function Detect-Python {
-  if(-not ($env:PYPE_PYTHON_EXE -eq "python")) {
+  if (Test-Path 'env:PYPE_PYTHON_EXE') {
     Log-Msg -Text ">>> ", "Forced using python at [ ", $env:PYPE_PYTHON_EXE ," ] ... " -Color Yellow, Gray, White, Gray -NoNewLine
+    $python = $env:PYPE_PYTHON_EXE
   } else {
     Log-Msg -Text ">>> ", "Detecting python ... " -Color Green, Gray -NoNewLine
     if (-not (Get-Command "python" -ErrorAction SilentlyContinue)) {
@@ -478,7 +475,7 @@ import sys
 print('{0}.{1}'.format(sys.version_info[0], sys.version_info[1]))
 '@
 
-  $p = & $env:PYPE_PYTHON_EXE -c $version_command
+  $p = & $python -c $version_command
   $m = $p -match '(\d+)\.(\d+)'
   if(-not $m) {
     Log-Msg -Text "FAILED", " Cannot determine version" -Color Red, Yellow
@@ -734,7 +731,7 @@ if ($deploy -eq $true) {
 Log-Msg -Text ">>> ", "Running ", "pype", " ..." -Color Green, Gray, White
 Write-Host ""
 $return_code = 0
-& $env:PYPE_PYTHON_EXE -m "pypeapp" @arguments
+& $python -m "pypeapp" @arguments
 if ($LASTEXITCODE -ne 0) {
   $return_code = $LASTEXITCODE
 }

--- a/pypeapp/__main__.py
+++ b/pypeapp/__main__.py
@@ -1,4 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Main entry point for Pype command."""
 from . import cli
+import sys
+import traceback
 
 if __name__ == '__main__':
-    cli.main(obj={}, prog_name="pype")
+    try:
+        cli.main(obj={}, prog_name="pype")
+    except Exception as e:
+        print("!!! Pype crashed:")
+        traceback.print_exception(type(e), e, e.__traceback__)
+        sys.exit(1)

--- a/pypeapp/__main__.py
+++ b/pypeapp/__main__.py
@@ -7,7 +7,8 @@ import traceback
 if __name__ == '__main__':
     try:
         cli.main(obj={}, prog_name="pype")
-    except Exception as e:
+    except Exception:
+        exc_info = sys.exc_info()
         print("!!! Pype crashed:")
-        traceback.print_exception(type(e), e, e.__traceback__)
+        traceback.print_exception(*exc_info)
         sys.exit(1)

--- a/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
+++ b/vendor/deadline/custom/plugins/GlobalJobPreLoad.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Remap pype path and PYPE_METADATA_PATH."""
+import platform
+from Deadline.Scripting import RepositoryUtils
+
+
+def pype_command_line(executable, arguments, workingDirectory):
+    """Remap paths in comand line argument string.
+
+    Using Deadline rempper it will remap all path found in command-line.
+
+    Args:
+        executable (str): path to executable
+        arguments (str): arguments passed to executable
+        workingDirectory (str): working directory path
+
+    Returns:
+        Tuple(executable, arguments, workingDirectory)
+
+    """
+    print("-" * 40)
+    print("executable: {}".format(executable))
+    print("arguments: {}".format(arguments))
+    print("workingDirectory: {}".format(workingDirectory))
+    print("-" * 40)
+    print("Remapping arguments ...")
+    arguments = RepositoryUtils.CheckPathMapping(arguments)
+    print("* {}".format(arguments))
+    print("-" * 40)
+    return executable, arguments, workingDirectory
+
+
+def pype(deadlinePlugin):
+    """Remaps `PYPE_METADATA_FILE` and `PYPE_PYTHON_EXE` environment vars.
+
+    `PYPE_METADATA_FILE` is used on farm to point to rendered data. This path
+    originates on platform from which this job was published. To be able to
+    publish on different platform, this path needs to be remapped.
+
+    `PYPE_PYTHON_EXE` can be used to specify custom location of python
+    interpreter to use for Pype. This is remappeda also if present even
+    though it probably doesn't make much sense.
+
+    Arguments:
+        deadlinePlugin: Deadline job plugin passed by Deadline
+
+    """
+    job = deadlinePlugin.GetJob()
+    pype_metadata = job.GetJobEnvironmentKeyValue("PYPE_METADATA_FILE")
+    pype_python = job.GetJobEnvironmentKeyValue("PYPE_PYTHON_EXE")
+    # test if it is pype publish job.
+    if pype_metadata:
+        pype_metadata = RepositoryUtils.CheckPathMapping(pype_metadata)
+        if platform.system().lower() == "linux":
+            pype_metadata = pype_metadata.replace("\\", "/")
+
+        print("- remapping PYPE_METADATA_FILE: {}".format(pype_metadata))
+        job.SetJobEnvironmentKeyValue("PYPE_METADATA_FILE", pype_metadata)
+        deadlinePlugin.SetProcessEnvironmentVariable(
+            "PYPE_METADATA_FILE", pype_metadata)
+
+    if pype_python:
+        pype_python = RepositoryUtils.CheckPathMapping(pype_python)
+        if platform.system().lower() == "linux":
+            pype_python = pype_python.replace("\\", "/")
+
+        print("- remapping PYPE_PYTHON_EXE: {}".format(pype_python))
+        job.SetJobEnvironmentKeyValue("PYPE_PYTHON_EXE", pype_python)
+        deadlinePlugin.SetProcessEnvironmentVariable(
+            "PYPE_PYTHON_EXE", pype_python)
+
+    deadlinePlugin.ModifyCommandLineCallback += pype_command_line
+
+
+def __main__(deadlinePlugin):
+    pype(deadlinePlugin)

--- a/vendor/deadline/readme.md
+++ b/vendor/deadline/readme.md
@@ -1,0 +1,3 @@
+## Pype Deadline repository overlay
+
+ This directory is overlay for Deadline repository. It means that you can copy whole hierarchy to Deadline repository and it should work.

--- a/vendor/python/acre/acre/lib.py
+++ b/vendor/python/acre/acre/lib.py
@@ -46,6 +46,8 @@ def partial_format(s, data, missing="{{{key}}}"):
         f = formatter.vformat(s, (), mapping)
     except ValueError:
         return s
+    except TypeError:
+        return s
     return f
 
 


### PR DESCRIPTION
## Problem

### Python Interpreter
Pype was using only Python it has detected as its interpreter and there was no way to provide custom one.

### Deadline `GlobalJobPreLoad.py`
As Deadline is not remapping by default paths in environment variables, path to `PYPE_METADATA_FILE` was left untouched and not recognized by other platform then the one originating from.

### Handling of exit codes
Pype was not consistent with how it handled its exit codes. This could result in job in Deadline to be marked as complete even though it failed as Pype exited with status code 0.

## Solution

This PR introduce re-use of `PYPE_PYTHON_EXE` environment variable. If used, it will override python detection and use python on path provided.

*❕ it will still check for compatible version*

This PR is providing Deadline repo overlay found in `vendor/deadline`. This can be copyied to Deadline repository. Currently it is hosting just `GlobalJobPreLoad.py` script that is taking care of remapping `PYPE_METADATA_FILE`, `PYPE_PYTHON_EXE` and command-line arguments for pype publishing.

Pype will now report correct status codes on exit.

fixes pypeclub/pype#116