### PR TITLE
flag for pype staging in environment

### DIFF
--- a/pypeapp/tray.py
+++ b/pypeapp/tray.py
@@ -5,23 +5,6 @@ from pypeapp import style, Logger
 from Qt import QtCore, QtGui, QtWidgets, QtSvg
 from pypeapp.lib.config import get_presets
 from pypeapp.resources import get_resource
-try:
-    import configparser
-except Exception:
-    import ConfigParser as configparser
-
-IS_DEV = False
-cur_dir = os.path.dirname(os.path.abspath(__file__))
-config_file_path = os.path.join(cur_dir, "config.ini")
-if os.path.exists(config_file_path):
-    config = configparser.ConfigParser()
-    config.read(config_file_path)
-    try:
-        value = config["DEFAULT"]["dev"]
-        if value.lower() == "true":
-            IS_DEV = True
-    except KeyError:
-        pass
 
 
 class SystemTrayIcon(QtWidgets.QSystemTrayIcon):
@@ -31,7 +14,7 @@ class SystemTrayIcon(QtWidgets.QSystemTrayIcon):
     :type parent: QtWidgets.QMainWindow
     """
     def __init__(self, parent):
-        if IS_DEV:
+        if os.getenv("PYPE_DEV"):
             icon_file_name = "icon_dev.png"
         else:
             icon_file_name = "icon.png"
@@ -506,7 +489,7 @@ class Application(QtWidgets.QApplication):
         self.splash.hide()
 
     def set_splash(self):
-        if IS_DEV:
+        if os.getenv("PYPE_DEV"):
             splash_file_name = "splash_dev.png"
         else:
             splash_file_name = "splash.png"


### PR DESCRIPTION
## Problem

Sometimes it is useful to know if we are in *staging* or in *production* branch. We are now utilizing flags in `pypepapp/config.ini` but this was currently used only in tray to show branch-specific splash and icons.

## Solution

Processing of  `pypepapp/config.ini` is moved to `PypeLauncher._initialize()` where `PYPE_DEV` environment variable is set if we are in staging variant. This can be then used later on.

## Minor changes

Printing of information during pype startup had hardcoded `\t` inside, this was remade so it use spaces and more intelligent padding. This should produce more readable output.