### PR TITLE
Do not check for executable permissions on linux

### DIFF
--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -736,11 +736,6 @@ class PypeLauncher(object):
                     return
 
                 fp.close()
-                # check executable permission
-                if not os.access(execfile, os.X_OK):
-                    t.echo("!!! No executable permission on [ {} ]".format(
-                        execfile))
-                    return
             else:
                 t.echo("!!! Launcher doesn\'t exist [ {} ]".format(
                     execfile))


### PR DESCRIPTION
## Problem

As reported by one of our clients, this check on linux fails even if those `+x` are set. If we delete this check it will still work and in worst case fail on permission error if those executable permissions are not really set.