### PR TITLE
bugfix/ftrack event server path fix

### DIFF
--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -254,8 +254,8 @@ class PypeLauncher(object):
 
         pype_setup = os.getenv('PYPE_SETUP_PATH')
         items = [
-            pype_setup, "repos", "pype", "pype", "ftrack", "ftrack_server",
-            "event_server.py"
+            pype_setup, "repos", "pype", "pype", "modules",
+            "ftrack", "ftrack_server", "event_server.py"
         ]
         fname = os.path.sep.join(items)
 
@@ -278,8 +278,8 @@ class PypeLauncher(object):
 
         pype_setup = os.getenv('PYPE_SETUP_PATH')
         items = [
-            pype_setup, "repos", "pype", "pype", "ftrack", "ftrack_server",
-            "event_server_cli.py"
+            pype_setup, "repos", "pype", "pype", "modules",
+            "ftrack", "ftrack_server", "event_server_cli.py"
         ]
         fname = os.path.sep.join(items)
 


### PR DESCRIPTION
Issues:
Path to event server executable was not changed during moving modules for pype 3.

Solution:
Added "modules" to path calculations.