### PR TITLE
Stop automatic environment appending

### DIFF
--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -115,10 +115,11 @@ class PypeLauncher(object):
             if key.startswith('PYPE_'):
                 pype_paths_env[key] = value
 
-        env = acre.append(tools_env, pype_paths_env)
+        env = tools_env
+        env.update(pype_paths_env)
         env = acre.compute(env, cleanup=True)
-        os.environ = acre.append(dict(os.environ), env)
-        os.environ = acre.compute(os.environ, cleanup=False)
+        env = acre.merge(env, os.environ)
+        os.environ = env
 
     def launch_tray(self, debug=False):
         """Run tray.py.


### PR DESCRIPTION
## Problem

When pype started, we automatically appended all Pype related enviornment variables into existing one, even if it didn't make sense. For example: if there was already environment variable `FOO="apple"` and we defined in our jsons `FOO="orange"` it resulted in `FOO="apple;orange"`. This behaviour made sense for some path variables, but it did break few others where multiple values are not expected or allowed.

## Solution

Environments are now not appended automatically. This has lesser impact then expected - only `PATH` and `PYTHONPATH` variables are affected and they can be easily remedied in **pype-config** like:

```javascript
{
    "PATH": [
        "/some/path",
        "{PATH}"
    ]
}
```
This will append `PATH` to `/some/path`

Acre doesn't allow list in platform specific values:

```javascript
{
    "PATH": {
        "windows": ["path1", "path2", "{PATH}"],
        "linux": ["path1", "path2", "{PATH}"]
    }
}
```
**is unfortunately not possible** ⚠️
but can be done as:
```javascript
{
    "PATH": {
        "windows": "path1;path2;{PATH}",
        "linux": "path1:path2:{PATH}"
    }
}
```
*(notice platform specific path separators)*

relates to pypeclub/pype-config#42 :eye:
|---|