### PR TITLE
Feature/modify cloud mongo

### DIFF
--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -315,7 +315,7 @@ class PypeLogger:
         _bootstrap_mongo_log(components)
 
         kwargs = {
-            "host": components["host"],
+            "host": compose_url(**components),
             "database_name": LOG_DATABASE_NAME,
             "collection": LOG_COLLECTION_NAME,
             "username": components["username"],

--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -17,7 +17,6 @@ import os
 import sys
 import datetime
 import time
-import datetime as dt
 import platform
 import getpass
 import socket
@@ -204,7 +203,7 @@ class PypeMongoFormatter(logging.Formatter):
         """Formats LogRecord into python dictionary."""
         # Standard document
         document = {
-            'timestamp': dt.datetime.now(),
+            'timestamp': datetime.datetime.now(),
             'level': record.levelname,
             'thread': record.thread,
             'threadName': record.threadName,

--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -74,7 +74,11 @@ def _bootstrap_mongo_log():
     """
     import pymongo
 
-    components = decompose_url(os.environ["MONGO_URL"])
+    mongo_url = os.environ.get("PYPE_LOG_MONGO_URL")
+    if mongo_url is not None:
+        components = decompose_url(mongo_url)
+    else:
+        components = get_default_components()
 
     if not components["host"] or not components["port"]:
         # fail silently

--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -88,7 +88,6 @@ def _bootstrap_mongo_log():
 
     uri = compose_url(**components)
 
-    print(">>> connecting to log [ {} ]".format(uri))
 
     port = components.pop("port")
     components.pop("database")

--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -43,8 +43,8 @@ except NameError:
 
 
 PYPE_DEBUG = int(os.getenv("PYPE_DEBUG", "0"))
-DATABASE = os.environ.get("PYPE_LOG_MONGO_DB") or "pype"
-COLLECTION = os.environ.get("PYPE_LOG_MONGO_COL") or "logs"
+LOG_DATABASE_NAME = os.environ.get("PYPE_LOG_MONGO_DB") or "pype"
+LOG_COLLECTION_NAME = os.environ.get("PYPE_LOG_MONGO_COL") or "logs"
 
 system_name, pc_name = platform.uname()[:2]
 host_name = socket.gethostname()

--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -24,7 +24,12 @@ import socket
 from logging.handlers import TimedRotatingFileHandler
 
 from pypeapp.lib.Terminal import Terminal
-from .mongo import decompose_url, compose_url
+from .mongo import (
+    MongoEnvNotSet,
+    decompose_url,
+    compose_url,
+    get_default_components
+)
 
 try:
     from log4mongo.handlers import MongoHandler
@@ -68,17 +73,23 @@ else:
             process_name = os.path.basename(sys.executable)
 
 
-def _bootstrap_mongo_log():
-    """
-    This will check if database and collection for logging exist on server.
-    """
-    import pymongo
-
+def _log_mongo_components():
     mongo_url = os.environ.get("PYPE_LOG_MONGO_URL")
     if mongo_url is not None:
         components = decompose_url(mongo_url)
     else:
         components = get_default_components()
+    return components
+
+
+def _bootstrap_mongo_log(components=None):
+    """
+    This will check if database and collection for logging exist on server.
+    """
+    import pymongo
+
+    if components is None:
+        components = _log_mongo_components()
 
     if not components["host"] or not components["port"]:
         # fail silently

--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -92,7 +92,7 @@ def _bootstrap_mongo_log(components=None):
     if components is None:
         components = _log_mongo_components()
 
-    if not components["host"] or not components["port"]:
+    if not components["host"]:
         # fail silently
         return
 

--- a/pypeapp/lib/mongo.py
+++ b/pypeapp/lib/mongo.py
@@ -79,4 +79,5 @@ def compose_url(scheme=None,
 
 
 def get_default_components():
-    return decompose_url(os.environ["MONGO_URL"])
+    mongo_url = os.environ.get("AVALON_MONGO")
+    return decompose_url(mongo_url)

--- a/pypeapp/lib/mongo.py
+++ b/pypeapp/lib/mongo.py
@@ -13,7 +13,7 @@ def decompose_url(url):
         "port": None,
         "username": None,
         "password": None,
-        "auth_db": ""
+        "auth_db": None
     }
 
     result = urlparse(url)
@@ -43,7 +43,7 @@ def compose_url(scheme=None,
                 database=None,
                 collection=None,
                 port=None,
-                auth_db=""):
+                auth_db=None):
 
     url = "{scheme}://"
 
@@ -61,7 +61,8 @@ def compose_url(scheme=None,
     if port:
         url += ":{port}"
 
-    url += auth_db
+    if auth_db:
+        url += "?authSource={auth_db}"
 
     return url.format(**{
         "scheme": scheme,
@@ -71,7 +72,7 @@ def compose_url(scheme=None,
         "database": database,
         "collection": collection,
         "port": port,
-        "auth_db": ""
+        "auth_db": auth_db
     })
 
 

--- a/pypeapp/lib/mongo.py
+++ b/pypeapp/lib/mongo.py
@@ -6,6 +6,10 @@ except ImportError:
     from urlparse import urlparse, parse_qs
 
 
+class MongoEnvNotSet(Exception):
+    pass
+
+
 def decompose_url(url):
     components = {
         "scheme": None,
@@ -80,4 +84,8 @@ def compose_url(scheme=None,
 
 def get_default_components():
     mongo_url = os.environ.get("AVALON_MONGO")
+    if mongo_url is None:
+        raise MongoEnvNotSet(
+            "URL for Mongo logging connection is not set."
+        )
     return decompose_url(mongo_url)

--- a/pypeapp/lib/mongo.py
+++ b/pypeapp/lib/mongo.py
@@ -17,6 +17,9 @@ def decompose_url(url):
     }
 
     result = urlparse(url)
+    if result.scheme is None:
+        _url = "mongodb://{}".format(url)
+        result = urlparse(_url)
 
     components["scheme"] = result.scheme
     components["host"] = result.hostname

--- a/pypeapp/lib/mongo.py
+++ b/pypeapp/lib/mongo.py
@@ -54,15 +54,14 @@ def compose_url(scheme=None,
         url += "{username}:{password}@"
 
     url += "{host}"
+    if port:
+        url += ":{port}"
 
     if database:
         url += "/{database}"
 
     if database and collection:
         url += "/{collection}"
-
-    if port:
-        url += ":{port}"
 
     if auth_db:
         url += "?authSource={auth_db}"

--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -13,6 +13,7 @@ class PypeLauncher(object):
         """Print additional information to console."""
         from pypeapp.lib.Terminal import Terminal
         from pypeapp.lib.mongo import get_default_components
+        from pypeapp.lib.log import LOG_DATABASE_NAME, LOG_COLLECTION_NAME
 
         t = Terminal()
         components = get_default_components()
@@ -39,23 +40,11 @@ class PypeLauncher(object):
                           os.environ.get("MUSTER_REST_URL")))
 
         if components["host"]:
-            if os.environ.get("PYPE_LOG_MONGO_COL"):
-                infos.append((
-                    "Logging to mongodb",
-                    "{}/{}".format(
-                        components["host"], os.environ["PYPE_LOG_MONGO_DB"]
-                    )
-                ))
-            else:
-                infos.append(("Logging to mongodb", components["host"]))
-            if components["port"]:
-                infos.append(("  - port", components["port"]))
-            if components["username"]:
-                infos.append(("  - user", components["username"]))
-            if os.environ.get("PYPE_LOG_MONGO_COL"):
-                infos.append((
-                    "  - collection", os.environ["PYPE_LOG_MONGO_COL"]
-                ))
+            infos.append(("Logging to MongoDB", components["host"]))
+            infos.append(("  - port", components["port"] or "<N/A>"))
+            infos.append(("  - database", LOG_DATABASE_NAME))
+            infos.append(("  - collection", LOG_COLLECTION_NAME))
+            infos.append(("  - user", components["username"] or "<N/A>"))
             if components["auth_db"]:
                 infos.append(("  - auth source", components["auth_db"]))
 

--- a/pypeapp/pypeLauncher.py
+++ b/pypeapp/pypeLauncher.py
@@ -365,12 +365,6 @@ class PypeLauncher(object):
         self._load_default_environments(tools=tools)
         self.print_info()
 
-        components = get_default_components()
-        port = components.pop("port")
-        host = compose_url(**components)
-        os.environ["AVALON_MONGO_HOST"] = host
-        os.environ["AVALON_MONGO_PORT"] = str(port)
-
     def texture_copy(self, project, asset, path):
         """Copy textures specified in path asset publish directory.
 


### PR DESCRIPTION
## Changes
- prints about mongo logging are correct
- mongo logging is happening even if `PYPE_LOG_MONGO_HOST` is not set
- renamed `DATABASE` variable to `LOG_DATABASE_NAME` and `COLLECTION` to `LOG_COLLECTION_NAME`
- default mongo url environment is not `MONGO_URL` but `AVALON_MONGO`
- port in `compose_url` is in right place now
- authentication database can be used
- if port is not set in url then default is used
- `AVALON_MONGO_PORT` and `AVALON_MONGO_HOST` are not set
- local mongo use port from `get_default_components` instead of `AVALON_MONGO_PORT` environemnt
- fixed local mongo launch on linux (was skipped)

### Requires
- pype-setup
- pype
- pype-config
- avalon-core