### PR TITLE
hotfix/qt working on mac

### DIFF
--- a/pype
+++ b/pype
@@ -615,7 +615,7 @@ main () {
 
   # Clean pyc
   if [ "$f_clean" == 1 ] ; then
-    clear_pyc
+    clean_pyc
     echo -e "${ICyan}<<<${RST} Terminating ${IWhite}Pype${RST} ..."
     return 0
   fi

--- a/pypeapp/requirements.txt
+++ b/pypeapp/requirements.txt
@@ -37,8 +37,8 @@ Pygments==2.3.1
 pymongo==3.7.2
 pynput==1.4
 pyparsing==2.3.1
-PyQt5==5.15.0
-PyQt5-sip==12.8.0
+PyQt5==5.14.2
+PyQt5-sip==12.7.2
 pytest==4.3.0
 pytest-cov==2.6.1
 pytest-print==0.1.2


### PR DESCRIPTION
## Issue
QPushButton in Qt does not work on Mac OS if there are set few specific stylesheet values. (`background-color`, `border-radius`, etc.)

## Solution
Downgraded PyQt5 to 5.14.2 which works on Mac OS.