### PR TITLE
Bugfix/mongo rul components

### DIFF
--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -96,15 +96,15 @@ def _bootstrap_mongo_log(components=None):
         # fail silently
         return
 
-    components["database"] = LOG_DATABASE_NAME
+    timeout = int(os.environ.get("AVALON_TIMEOUT", 1000))
     kwargs = {
-        "host": compose_url(**components)
+        "host": compose_url(**components),
+        "serverSelectionTimeoutMS": timeout
     }
 
     port = components.get("port")
     if port is not None:
         kwargs["port"] = int(port)
-
     client = pymongo.MongoClient(**kwargs)
     logdb = client[LOG_DATABASE_NAME]
 

--- a/pypeapp/lib/mongo.py
+++ b/pypeapp/lib/mongo.py
@@ -47,8 +47,6 @@ def compose_url(scheme=None,
                 host=None,
                 username=None,
                 password=None,
-                database=None,
-                collection=None,
                 port=None,
                 auth_db=None):
 
@@ -61,12 +59,6 @@ def compose_url(scheme=None,
     if port:
         url += ":{port}"
 
-    if database:
-        url += "/{database}"
-
-    if database and collection:
-        url += "/{collection}"
-
     if auth_db:
         url += "?authSource={auth_db}"
 
@@ -75,8 +67,6 @@ def compose_url(scheme=None,
         "host": host,
         "username": username,
         "password": password,
-        "database": database,
-        "collection": collection,
         "port": port,
         "auth_db": auth_db
     })


### PR DESCRIPTION
## Changes
- timeout for mongo logging connection is taken from `AVALON_TIMEOUT` environment variable
- `compose_url` does not care about database name and collection name