### PR TITLE
pype didn't run in folder with space 

### DIFF
--- a/pype.bat
+++ b/pype.bat
@@ -1,3 +1,3 @@
 @echo off
 pushd %~dp0
-powershell -NoProfile -noexit -nologo -executionpolicy bypass -command "%~dp0pype.ps1 %*; exit $LASTEXITCODE"
+powershell -NoProfile -noexit -nologo -executionpolicy bypass -command ".\pype.ps1 %*; exit $LASTEXITCODE"


### PR DESCRIPTION
- has been tested on Google Drive Stream with `G:\Shared drives` and all went fine.