### PR TITLE
compatibility fix with older Deadline versions

### DIFF
--- a/vendor/deadline/custom/plugins/MayaPype/MayaPype.py
+++ b/vendor/deadline/custom/plugins/MayaPype/MayaPype.py
@@ -2081,7 +2081,7 @@ class MayaBatchPlugin(DeadlinePlugin):
                 "Do not call CreateDelayedLoadingMelscript unless delayed loading is enabled."
             )
 
-        scriptBuilder.AppendJoin("\n", self.build_dirmap_commands())
+        scriptBuilder.AppendLine("\n".join(self.build_dirmap_commands()))
         scriptBuilder.AppendLine()
 
         # Force load plug-ins that Maya does not properly auto-load when the scene depends on them


### PR DESCRIPTION
## Fix

Our **MayaPype** plugin wasn't compatible with older Deadline version because of one line call to deadline api not available in previous deadline versions.