### PR TITLE
fix bin localization during installation phase

### DIFF
--- a/pype
+++ b/pype
@@ -50,6 +50,7 @@ f_force=0
 f_mongodb=0
 f_update=0
 f_clean=0
+f_localize=0
 venv_activated=0
 # Process arguments
 # .
@@ -90,6 +91,9 @@ while :; do
       ;;
     clean)
       f_clean=1
+      ;;
+    localize)
+      f_localize=1
       ;;
     --)
       shift
@@ -793,6 +797,12 @@ main () {
     echo -e "${IGreen}>>>${RST} Validating ${BIWhite}Pype${RST} deployment ..."
     validate_pype || return 1
     echo -e "${BIGreen}>>>${RST} Deployment is ${BIGreen}OK${RST}"
+    localize_bin || return 1
+    return
+  fi
+
+  if [ "$f_localize" == 1 ] ; then
+    localize_bin || return 1
     return
   fi
 

--- a/pype.ps1
+++ b/pype.ps1
@@ -97,6 +97,9 @@ if($arguments -eq "update-requirements") {
 if($arguments -eq "clean") {
   $clean=$true
 }
+if($arguments -eq "localize") {
+  $localize=$true
+}
 
 
 # -----------------------------------------------------------------------------
@@ -647,9 +650,6 @@ if ($needToInstall -eq $true) {
   # bootstrap pype
   Bootstrap-Pype
 
-  # localize bin
-  Localize-Bin
-
 } else {
   Log-Msg -Text "FOUND", " - [ ", $env:PYPE_ENV, " ]" -Color Green, Gray, White, Gray
   Activate-Venv -Environment $env:PYPE_ENV
@@ -733,7 +733,16 @@ if ($deploy -eq $true) {
     Deactivate-Venv
     ExitWithCode 0
   }
+  # localize bin
+  Localize-Bin
 }
+if ($localize -eq $true) {
+  # localize bin
+  Localize-Bin
+  Deactivate-Venv
+  ExitWithCode 0
+}
+
 
 Log-Msg -Text ">>> ", "Running ", "pype", " ..." -Color Green, Gray, White
 Write-Host ""


### PR DESCRIPTION
## Problem

We were trying to localize binaries in `/vendor/bin` during **pype install** phase but there is nothing to localize until **pype deploy** is run.

## Fix

So this fix moved binaries localization to deploy phase and added `localize` as a Pype command, so `pype localize` will copy binaries to local environment.