### PR TITLE
deployment.py now expands vars in deploy,json urls

### DIFF
--- a/pypeapp/deployment.py
+++ b/pypeapp/deployment.py
@@ -500,7 +500,7 @@ class Deployment(object):
         term.echo(">>> Deploying repositories ...")
         for ritem in deploy.get('repositories'):
             path = os.path.join(
-                self._pype_root, "repos", ritem.get('name'))
+                self._pype_root, "repos", os.path.expandvars(ritem.get('name')))
 
             term.echo(" -- processing [ {} / {} ]".format(
                 ritem.get('name'), ritem.get('branch') or ritem.get('tag')))


### PR DESCRIPTION
Given that pype-setup allows for custom deploy.json with user specified urls of repos such as pype-config, it makes sense to expandvars for environment variables for private keys in the repo url. 
I have added this by simply adding os.path.expandvars in the definition of the 'path' var in deployment.py.

This will expand vars in linux like: $MY_ENV_VAR or in windows: %MY_ENV_VAR%.

