### PR TITLE
support for post install and pre-run scripts

### DIFF
--- a/deploy/post-install.sh.example
+++ b/deploy/post-install.sh.example
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# This script is addressing issue on mac with Google File Stream.
+# In some cases, if it is not ready during boot it will destroy the link
+# pointing to it, making it into empty directory.
+# This will check if link is still link to directory and if not, it is moved
+# to backup name and recreated. If backup already exists, it is removed.
+
+echo "--- Check Google Drive links ..."
+root_link_location="/usr/local/pype/root"
+root_cloud_location="/Users/annatar/Google Drive/novartis"
+if [[ -L "$root_link_location" && -d "$root_link_location" ]]; then
+ echo "  - $root_link_location is link, no action needed."
+else
+  if [[ -f "$root_link_location" || -d "$root_link_location" ]]; then
+    if [[ -f "$root_link_location".backup || -d "$root_link_location".backup ]]; then
+      echo "  . backup already exist, removing old ..."
+      rm -rf "$root_link_location".backup
+    fi
+    echo "  - creating backup ..."
+    mv -f "$root_link_location" "$root_link_location".backup
+  fi
+  echo "  - creating new link [ $root_link_location ] -> [ $root_cloud_location ]"
+  ln -s "$root_cloud_location" "$root_link_location"
+fi
+echo "... done"

--- a/deploy/pre-run.sh.example
+++ b/deploy/pre-run.sh.example
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# This script is addressing issue on mac with Google File Stream.
+# In some cases, if it is not ready during boot it will destroy the link
+# pointing to it, making it into empty directory.
+# This will check if link is still link to directory and if not, it is moved
+# to backup name and recreated. If backup already exists, it is removed.
+
+echo "--- Check Google Drive links ..."
+root_link_location="/usr/local/pype/root"
+root_cloud_location="/Users/annatar/Google Drive/novartis"
+if [[ -L "$root_link_location" && -d "$root_link_location" ]]; then
+ echo "  - $root_link_location is link, no action needed."
+else
+  if [[ -f "$root_link_location" || -d "$root_link_location" ]]; then
+    if [[ -f "$root_link_location".backup || -d "$root_link_location".backup ]]; then
+      echo "  . backup already exist, removing old ..."
+      rm -rf "$root_link_location".backup
+    fi
+    echo "  - creating backup ..."
+    mv -f "$root_link_location" "$root_link_location".backup
+  fi
+  echo "  - creating new link [ $root_link_location ] -> [ $root_cloud_location ]"
+  ln -s "$root_cloud_location" "$root_link_location"
+fi
+echo "... done"

--- a/launchers/maya_render.bat
+++ b/launchers/maya_render.bat
@@ -1,5 +1,6 @@
 @echo off
 cls
 net use
+set PYPE_SETUP_PATH=%~dp0..\
 echo "arguments: %*"
 %PYPE_SETUP_PATH%\pype.bat launch --app mayabatch_%PYPE_MAYA_VERSION% %*

--- a/launchers/maya_render.sh
+++ b/launchers/maya_render.sh
@@ -4,4 +4,5 @@ echo ">>> running as:"
 who
 id -Gn
 echo ">>> launching mayabatch via pype with arguments $@"
+export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
 source "$PYPE_SETUP_PATH/pype" launch --app mayabatch_$PYPE_MAYA_VERSION $@

--- a/pype
+++ b/pype
@@ -749,6 +749,8 @@ main () {
   fi
 
   if [ "$f_install" == 1 ] ; then
+    echo -e "${IGreen}>>>${RST} Checking for and running any post-installation scripts ..."
+    find ./deploy -name 'post-install.sh' -print0 | xargs -0 bash -c
     echo -e "${IGreen}***${RST} Installation complete. ${IWhite}Have a nice day!${RST}"
     return 0
   fi
@@ -796,6 +798,8 @@ main () {
     return
   fi
 
+  echo -e "${IGreen}>>>${RST} Checking for and running any pre run scripts ..."
+  find ./deploy -name 'prerun-install.sh' -print0 | xargs -0 bash -c
   echo -e "${IGreen}>>>${RST} Running ${IWhite}Pype${RST} ..."
   $PYTHON -m pypeapp $args || return $?
   echo -e "${IPurple}xxx${RST} Finishing up. ${IWhite}Have a nice day!${RST}"

--- a/pype
+++ b/pype
@@ -604,7 +604,7 @@ localize_bin () {
 clean_pyc () {
   path=${1:-$PYPE_SETUP_PATH}
   echo -e "${IGreen}>>>${RST} Cleaning pyc at [ ${BIWhite}$path${RST} ] ... \c"
-  find . -name '*.py?' -delete
+  find "$path" -name '*.py?' -delete
   echo -e "${BIGreen}DONE${RST}"
 }
 
@@ -750,7 +750,7 @@ main () {
 
   if [ "$f_install" == 1 ] ; then
     echo -e "${IGreen}>>>${RST} Checking for and running any post-installation scripts ..."
-    find ./deploy -name 'post-install.sh' -print0 | xargs -0 bash -c
+    find "$PYPE_SETUP_PATH/deploy" -name 'post-install.sh' -print0 | xargs -0 bash -c
     echo -e "${IGreen}***${RST} Installation complete. ${IWhite}Have a nice day!${RST}"
     return 0
   fi
@@ -799,7 +799,7 @@ main () {
   fi
 
   echo -e "${IGreen}>>>${RST} Checking for and running any pre run scripts ..."
-  find ./deploy -name 'prerun-install.sh' -print0 | xargs -0 bash -c
+  find "$PYPE_SETUP_PATH/deploy" -name 'prerun-install.sh' -print0 | xargs -0 bash -c
   echo -e "${IGreen}>>>${RST} Running ${IWhite}Pype${RST} ..."
   $PYTHON -m pypeapp $args || return $?
   echo -e "${IPurple}xxx${RST} Finishing up. ${IWhite}Have a nice day!${RST}"

--- a/pype.ps1
+++ b/pype.ps1
@@ -657,6 +657,8 @@ if ($needToInstall -eq $true) {
   # Upgrade-pip
 }
 if ($install -eq $true) {
+  Log-Msg -Text ">>> ", "Checking for and running any post-installation scripts ..." -Color Green, Gray
+  Get-ChildItem "$($env:PYPE_SETUP_PATH)\deploy" -Filter "post-install.ps1" -Force -Recurse | Foreach {& $_.fullname}
   Log-Msg -Text "*** ", "Installation complete. ", "Have a nice day!" -Color Green, White, Gray
   Deactivate-Venv
   ExitWithCode 0
@@ -735,6 +737,8 @@ if ($deploy -eq $true) {
   }
 }
 
+Log-Msg -Text ">>> ", "Checking for and running any pre-run scripts ..." -Color Green, Gray
+Get-ChildItem "$($env:PYPE_SETUP_PATH)\deploy" -Filter "pre-run.ps1" -Force -Recurse | Foreach {& $_.fullname}
 Log-Msg -Text ">>> ", "Running ", "pype", " ..." -Color Green, Gray, White
 Write-Host ""
 $return_code = 0

--- a/pypeapp/requirements.py
+++ b/pypeapp/requirements.py
@@ -6,6 +6,7 @@ will trigger packages installation in parent shell script.
 """
 import sys
 import subprocess
+import os
 
 # get pip installed packages
 installed_req = subprocess.check_output(
@@ -18,7 +19,9 @@ installed_req = [s.lower() for s in installed_req]
 
 # read required dependencies and expect it in UTF-8 BOM. This is produced
 # by default on Windows with Poweshell, but works with non-BOM and ASCII too.
-with open("pypeapp/requirements.txt", "r", encoding="utf-8-sig") as rf:
+requirements = os.path.join(os.getenv("PYPE_SETUP_PATH"),
+                            "pypeapp", "requirements.txt")
+with open(requirements, "r", encoding="utf-8-sig") as rf:
     requested_req = rf.readlines()
 
 # clear those from endlines and make it lower


### PR DESCRIPTION
## Feature

This is adding new feature - to be able to run arbitraty scrips just after installation ends and/or before pype starts.

This is accomplished by looking recursively for scripts named `post-install` and `pre-run` in **deploy** and subsequent directories.

This adds ability to chain them - have one default and also studio specific.

There are two example scripts (not running by default until renamed) - actually just one in two files. It check one location if it is link to directory. If it is not, it will rename it to backup name and create the link anew.
