### PR TITLE
Hotfix: Mac installation improvements

### DIFF
--- a/deploy/post-install.sh.example
+++ b/deploy/post-install.sh.example
@@ -6,8 +6,9 @@
 # to backup name and recreated. If backup already exists, it is removed.
 
 echo "--- Check Google Drive links ..."
+current_user=$(who -m | awk '{print $1;}')
 root_link_location="/usr/local/pype/root"
-root_cloud_location="/Users/user/Google Drive/path"
+root_cloud_location="/Users/$current_user/Google Drive/My Drive/pypeRoot"
 if [[ -L "$root_link_location" && -d "$root_link_location" ]]; then
  echo "  - $root_link_location is link, no action needed."
 else

--- a/deploy/pre-run.sh.example
+++ b/deploy/pre-run.sh.example
@@ -6,8 +6,9 @@
 # to backup name and recreated. If backup already exists, it is removed.
 
 echo "--- Check Google Drive links ..."
+current_user=$(who -m | awk '{print $1;}')
 root_link_location="/usr/local/pype/root"
-root_cloud_location="/Users/user/Google Drive/path"
+root_cloud_location="/Users/$current_user/Google Drive/My Drive/pypeRoot"
 if [[ -L "$root_link_location" && -d "$root_link_location" ]]; then
  echo "  - $root_link_location is link, no action needed."
 else

--- a/pype
+++ b/pype
@@ -50,6 +50,8 @@ f_force=0
 f_mongodb=0
 f_update=0
 f_clean=0
+f_macIcons=0
+f_localize=0
 venv_activated=0
 # Process arguments
 # .
@@ -90,6 +92,12 @@ while :; do
       ;;
     clean)
       f_clean=1
+      ;;
+    mac-icons)
+      f_macIcons=1
+      ;;
+    localize-bin)
+      f_localize=1
       ;;
     --)
       shift
@@ -337,6 +345,9 @@ check_environment () {
     fi
     clean_pyc $PYPE_ENV
     clean_pyc
+    if [[ $OSTYPE =~ ^darwin.* ]]; then
+      f_macIcons=1
+    fi
   else
     echo -e "${BIGreen}OK${RST}"
   fi
@@ -604,7 +615,7 @@ localize_bin () {
 clean_pyc () {
   path=${1:-$PYPE_SETUP_PATH}
   echo -e "${IGreen}>>>${RST} Cleaning pyc at [ ${BIWhite}$path${RST} ] ... \c"
-  find "$path" -name '*.py?' -delete
+  find "$path" -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
   echo -e "${BIGreen}DONE${RST}"
 }
 
@@ -726,11 +737,11 @@ main () {
         fi
         # set icons on Mac
         echo -e "${IGreen}>>>${RST} Setting icon on Pype files ..."
-        for i in "$PYPE_SETUP_PATH/launchers/*.command"; do
+        for i in $PYPE_SETUP_PATH/launchers/*.command; do
           [ -f "$i" ] || break
-          $PYPE_SETUP_PATH/fileicon.sh set $i $PYPE_SETUP_PATH/pypeapp/pype.icns
+          $PYPE_SETUP_PATH/vendor/fileicon.sh set $i $PYPE_SETUP_PATH/pypeapp/pype.icns
         done
-        $PYPE_SETUP_PATH/fileicon.sh set $PYPE_SETUP_PATH/pype $PYPE_SETUP_PATH/pypeapp/pype.icns
+        $PYPE_SETUP_PATH/vendor/fileicon.sh set $PYPE_SETUP_PATH/pype $PYPE_SETUP_PATH/pypeapp/pype.icns
 
       fi
 
@@ -740,8 +751,24 @@ main () {
       # activate environment
       activate_venv $PYPE_ENV || return 1
 
+      # install wheel as it is sometimes missing in default venv
+      echo -e "${IGreen}>>>${RST} Installing wheel ..."
+      if [ "$_offline" == 1 ] ; then
+        pip3 install wheel --no-index --find-links "$PYPE_SETUP_PATH/vendor/packages" 2> /dev/null
+      else
+        pip3 install wheel 2> /dev/null
+      fi
+
       # bootstrap pype
       bootstrap_pype || return 1
+
+      if [[ $OSTYPE =~ ^darwin.* ]]; then
+        echo -e "${IGreen}>>>${RST} Fixing file permissions ...\c"
+        current_sudo_user=$(who -m | awk '{print $1;}')
+        execute_sudo chown -R $current_sudo_user $PYPE_ENV
+        execute_sudo chown -R $current_sudo_user "/Users/$current_sudo_user/Library/Caches/pip"
+        echo -e "${BIGreen}DONE${RST}"
+      fi
   else
     echo -e "${BIGreen}FOUND${RST} - [${BIWhite} $PYPE_ENV ${RST}]"
     activate_venv $PYPE_ENV || return 1
@@ -795,7 +822,26 @@ main () {
     echo -e "${IGreen}>>>${RST} Validating ${BIWhite}Pype${RST} deployment ..."
     validate_pype || return 1
     echo -e "${BIGreen}>>>${RST} Deployment is ${BIGreen}OK${RST}"
+    localize_bin || return 1
     return
+  fi
+
+  # Localize binaries
+  if [ "$f_localize" == 1 ] ; then
+    localize_bin || return 1
+    return
+
+  if [ "$f_macIcons" == 1 ] ; then
+    if [[ $OSTYPE =~ ^darwin.* ]]; then
+      echo -e "${IGreen}>>>${RST} Setting icon on Pype files ..."
+      for i in $PYPE_SETUP_PATH/launchers/*.command; do
+        [ -f "$i" ] || break
+        $PYPE_SETUP_PATH/vendor/fileicon.sh set $i $PYPE_SETUP_PATH/pypeapp/pype.icns
+      done
+      $PYPE_SETUP_PATH/vendor/fileicon.sh set $PYPE_SETUP_PATH/pype $PYPE_SETUP_PATH/pypeapp/pype.icns
+    else
+      echo -e "${BIYellow}***${RST} ${Yellow}Setting files icon can be done only on mac.${RST}"
+    fi
   fi
 
   echo -e "${IGreen}>>>${RST} Checking for and running any pre run scripts ..."


### PR DESCRIPTION
## Mac improvements

This small hotfix enhances installation and pype launching.

- `pype clean` will now clean *__pycache__* along *.pyc* and *.pyo* files
- ownership of `~/Library/Caches/pip` is fixed for correct user instead of root if run with sudo
- ownership of `/usr/local/pype` (**$PYPE_ENV**) is fixed for correct user instead of root if run with sudo
- **P.** icon is set for `pype` and `launchers/*.command` files during install
- added new command `pype mac-icons` to just fix above ⬆️ 
- added command `localize-bin` to manually copy stuff from `/vendor/bin` to **$PYPE_ENV**
- `post-install` and `pre-run` script now defaults to GDrive default location and automatically detect user directory. It should be enough now to just rename them and they should work without any other modification.