### PR TITLE
Bugfix/allow get root name from string

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -170,14 +170,14 @@ class Anatomy:
 
         output = set()
         if isinstance(data, dict):
-            for key, value in data.items():
-                if isinstance(value, dict):
-                    for root in self._root_keys_from_templates(value):
-                        output.add(root)
+            for value in data.values():
+                for root in self._root_keys_from_templates(value):
+                    output.add(root)
 
-                elif isinstance(value, str):
-                    for group in re.findall(self.root_key_regex, value):
-                        output.add(group)
+        elif isinstance(data, str):
+            for group in re.findall(self.root_key_regex, data):
+                output.add(group)
+
         return output
 
     def root_value_for_template(self, template):


### PR DESCRIPTION
## Issue
- anatomy's method `_root_keys_from_templates` allows only entering dictionaries for getting the root names

## Changes
- method modified to be able enter only template as string