### PR TITLE
syntax error in linux/mac pype shell script

### DIFF
--- a/pype
+++ b/pype
@@ -830,6 +830,7 @@ main () {
   if [ "$f_localize" == 1 ] ; then
     localize_bin || return 1
     return
+  fi
 
   if [ "$f_macIcons" == 1 ] ; then
     if [[ $OSTYPE =~ ^darwin.* ]]; then


### PR DESCRIPTION
There is missing `fi` in shell script breaking pype on linux and mac