### PR TITLE
Fix for pypeapp/cli.py and -ftrackeventpaths

### DIFF
--- a/pypeapp/cli.py
+++ b/pypeapp/cli.py
@@ -182,7 +182,7 @@ def eventserver(debug,
         args.append(ftrack_api_key)
 
     if ftrack_events_path:
-        args.append('-ftrackapikey')
+        args.append('-ftrackeventpaths')
         args.append(ftrack_events_path)
 
     if no_stored_credentials:


### PR DESCRIPTION
A fix for -ftrackevents path parameter which was set to -ftrackapikey, which resulted in calls for pype eventserver to clobber the api key with a duplicate flag when FTRACK_EVENT_PATHS was already in the environment.
      