### PR TITLE
Fix: validation of multiple tags per commit during deployment

### DIFF
--- a/pypeapp/deployment.py
+++ b/pypeapp/deployment.py
@@ -385,8 +385,8 @@ class Deployment(object):
         import git
         # get tag
         repo = git.Git(path)
-        rtag = repo.describe('--tags')
-        if rtag != tag:
+        rtags = repo.tag('--points-at', 'HEAD').splitlines()
+        if tag not in rtags:
             return False
         return True
 


### PR DESCRIPTION
## Problem

When running `deploy` or `validate`, validation of repository HEAD failed if there were multiple tags pointing to same commit. For example if there was commit *foo* with tags **2.11.0** and **2.11.1** and in `deploy,json` was **2.11.1** specified, validation only found **2.11.0** and marked repository check as failed.

Underlaying command `git describe --tags` only return first tag it finds, ignoring the rest. It is now changed to `git tag --points-at HEAD` that correctly returns all tags pointing to HEAD.