### PR TITLE
Added wsrpc-aiohttp for websocket server and Photoshop integration

### DIFF
--- a/pypeapp/requirements.txt
+++ b/pypeapp/requirements.txt
@@ -68,3 +68,4 @@ xlib==0.21
 zope.interface==5.1.0
 dnspython==1.16.0
 psd-tools==1.9.15
+wsrpc-aiohttp==3.0.1


### PR DESCRIPTION
What's changed?
Reiplementaion of Photoshop integration with websocket server and RPC, without com objects (eg. multiplatform).

Pype repo contains websocket server and implemented collectors and extractors.
Avalon-core contains basic api. Com objects and usage of http server were removed
Pype-setup contains added wsrpc-aiohttp library to requirements.txt

Extension needs to be installed to Phostoshop manually first, see https://github.com/kalisp/avalon-core/blob/feature/photoshop_with_websocket/avalon/photoshop/README.md

Requires:
pype:pypeclub/avalon-core#179
pype:pypeclub/pype#456
pype-config:pypeclub/pype-config#79