### PR TITLE
Feature/added windows oiio to bin vendor

### DIFF
--- a/deploy/deploy.json
+++ b/deploy/deploy.json
@@ -39,6 +39,11 @@
 	  "google_id": "1YmKxmJcJ9Bp_mPuHtLtCI-GsezxWUTdJ",
 	  "archive_type": "zip",
 	  "skip_first_subfolder": true
-	}
+    }, {
+	  "extract_path": "vendor/bin/oiiotool",
+	  "google_id": "1U1kMJO_mcqPBxfi2CMYgKBfnzal7Pj-h",
+	  "archive_type": "zip",
+	  "skip_first_subfolder": true
+    }
   ]
 }


### PR DESCRIPTION
## Changes
- next to FFmpeg binaries is also downloaded OpenImageIO tool for windows

## TODO
- localize oiiotool on user's machine if is windows
- We have to find a way how to install oiiotool on linux and mac (during pype installation on workstation?). I'm sure there will be a way how to do it with package managers etc.
    - APT `apt-get openimageio-tools`
    - Yum `yum install OpenImageIO-utils`
    - ...