### PR TITLE
Less mongo connections

### DIFF
--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -32,6 +32,14 @@ from .mongo import (
     get_default_components
 )
 
+# By default is mongo loggind enabled
+_mongo_logging = True
+mongo_log_enable = os.environ.get("PYPE_LOG_MONGO_ENABLED")
+if mongo_log_enable is not None:
+    mongo_log_enable = mongo_log_enable.lower()
+    if mongo_log_enable in ("false", "0", "no"):
+        _mongo_logging = False
+
 try:
     import log4mongo
     from log4mongo.handlers import MongoHandler


### PR DESCRIPTION
## Changes
- allow to disable mongo logging with `PYPE_LOG_MONGO_ENABLED` env variable
   - to disable mongo logging set `"PYPE_LOG_MONGO_ENABLED"` to `"0"`, `"no"` or `"false"`

|This depends on|  |
|---|---|
|avalon-core|https://github.com/pypeclub/avalon-core/pull/187|
|pype|https://github.com/pypeclub/pype/pull/509|