### PR TITLE
Hotfix/mongo logging enabling fix

### DIFF
--- a/pypeapp/lib/log.py
+++ b/pypeapp/lib/log.py
@@ -47,8 +47,6 @@ try:
     MONGO_PROCESS_ID = ObjectId()
 except ImportError:
     _mongo_logging = False
-else:
-    _mongo_logging = True
 
 try:
     unicode


### PR DESCRIPTION
## Changes
- fixed overriding `_mongo_logging` variable in log.py when importing of it's modules is sucessful