### PR TITLE
Fix: Handle space in Pype path in linux/osx

### DIFF
--- a/launchers/maya_render.sh
+++ b/launchers/maya_render.sh
@@ -4,5 +4,5 @@ echo ">>> running as:"
 who
 id -Gn
 echo ">>> launching mayabatch via pype with arguments $@"
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 source "$PYPE_SETUP_PATH/pype" launch --app mayabatch_$PYPE_MAYA_VERSION $@

--- a/launchers/pype_eventservercli.sh
+++ b/launchers/pype_eventservercli.sh
@@ -13,6 +13,6 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 
 source "$PYPE_SETUP_PATH/pype" eventserver

--- a/launchers/pype_install_workstation.command
+++ b/launchers/pype_install_workstation.command
@@ -13,6 +13,6 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 
 source "$PYPE_SETUP_PATH/pype" install --force

--- a/launchers/pype_install_workstation.sh
+++ b/launchers/pype_install_workstation.sh
@@ -13,6 +13,6 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 
 source "$PYPE_SETUP_PATH/pype" install --force

--- a/launchers/pype_localmongo.sh
+++ b/launchers/pype_localmongo.sh
@@ -13,6 +13,6 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 
 source "$PYPE_SETUP_PATH/pype" mongodb

--- a/launchers/pype_tray.command
+++ b/launchers/pype_tray.command
@@ -13,6 +13,6 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 
 source "$PYPE_SETUP_PATH/pype" tray --debug

--- a/launchers/pype_tray.sh
+++ b/launchers/pype_tray.sh
@@ -13,6 +13,6 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 
 source "$PYPE_SETUP_PATH/pype" tray

--- a/launchers/pype_traydebug.command
+++ b/launchers/pype_traydebug.command
@@ -13,7 +13,7 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 export PYPE_DEBUG=3
 
 source "$PYPE_SETUP_PATH/pype" tray --debug

--- a/launchers/pype_traydebug.sh
+++ b/launchers/pype_traydebug.sh
@@ -13,7 +13,7 @@
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-export PYPE_SETUP_PATH="$(cd $DIR/../ ; pwd)"
+export PYPE_SETUP_PATH=$(cd "$DIR"/../ ; pwd)
 export PYPE_DEBUG=3
 
 source "$PYPE_SETUP_PATH/pype" tray --debug

--- a/pype
+++ b/pype
@@ -27,7 +27,7 @@ EOF
 THIS=`readlink -f "${BASH_SOURCE[0]}" 2>/dev/null||echo $0`
 # The directory where current script resides
 DIR=`dirname "${THIS}"`
-pushd $DIR > /dev/null
+pushd "$DIR" > /dev/null
 # Set python interpreter name
 PYTHON="python3"
 # Set path to environment if not set
@@ -115,7 +115,7 @@ done
 
 # Set PYPE_SETUP_PATH to path to this script
 if [[ -z $PYPE_SETUP_PATH ]]; then
-  export PYPE_SETUP_PATH="$(cd $DIR; pwd)"
+  export PYPE_SETUP_PATH=$(cd "$DIR"; pwd)
 fi
 # Add PYPE_SETUP_PATH to PYTHONPATH if missing
 export PYTHONPATH=${PYTHONPATH:="$PYPE_SETUP_PATH/pypeapp"}


### PR DESCRIPTION
## Problem

When space was present in Pype path, launchers couldn't handle it on linux/osx.