### PR TITLE
Centos support

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import site
 import copy
 import platform
 import collections
@@ -14,6 +15,11 @@ from . import config
 from .log import PypeLogger
 
 try:
+    # Add venv site-packages to site dirs. On linux distributions this
+    # may not happen for `ruamel.yaml` module automatically.
+    site_packages_path = os.getenv("PYPE_SITE_PACKAGES")
+    if site_packages_path:
+        site.addsitedir(site_packages_path)
     import ruamel.yaml as yaml
 except ImportError:
     print("yaml module wasn't found, skipping anatomy")


### PR DESCRIPTION
## Description
- python module `ruamel.yaml` may not load properly on centos because pype's venv site packages in not registered in sites so pype's site-packages are added to sites always before `import ruamel.yaml`

|:black_flag: |this depends on|
|---|---|
|pype-config|https://github.com/pypeclub/pype-config/pull/92|
|pype|https://github.com/pypeclub/pype/pull/683|