### PR TITLE
Anatomy: make environment variables always string

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -1463,7 +1463,7 @@ class Roots:
     def set_root_environments(self):
         """Set root environments for current project."""
         for key, value in self.root_environments().items():
-            os.environ[key] = value
+            os.environ[key] = str(value)
 
     def root_environments(self):
         """Use root keys to create unique keys for environment variables.


### PR DESCRIPTION
## Problem

Sometimes root env variables set by Anatomy can be unicode strings - possibly even non string values. This makes sure Python 2 will pick them up as non-unicode strings and in Python 3 hosts it shouldn't matter.