### PR TITLE
Hotfix: Upgrade to PyQt 5.15.2 to address macOS big sur issues

### DIFF
--- a/pypeapp/requirements.txt
+++ b/pypeapp/requirements.txt
@@ -38,8 +38,8 @@ Pygments==2.3.1
 pymongo==3.7.2
 pynput==1.4
 pyparsing==2.3.1
-PyQt5==5.14.2
-PyQt5-sip==12.7.2
+PyQt5==5.15.2
+PyQt5-sip==12.8.1
 pytest==4.3.0
 pytest-cov==2.6.1
 pytest-print==0.1.2


### PR DESCRIPTION
## Problem

Pype Tray doesn't run with older versions of PyQt on macOS big sur. It stuck before opening any Qt UI elements. This solves it by upgrading our requirements to PyQt 5.15.2 that fixed this issue.