### PR TITLE
Anatomy environment replacement

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -256,6 +256,53 @@ class Anatomy:
         # NOTE does not care if there are different keys than "root"
         return template_path.format(**{"root": self.roots})
 
+    def replace_root_with_env_key(self, filepath, template=None):
+        """Replace root of path with environment key.
+
+        # Example:
+        ## Project with roots:
+        ```
+        {
+            "nas": {
+                "windows": P:/projects",
+                ...
+            }
+            ...
+        }
+        ```
+
+        ## Entered filepath
+        "P:/projects/project/asset/task/animation_v001.ma"
+
+        ## Entered template
+        "<{}>"
+
+        ## Output
+        "<PYPE_PROJECT_ROOT_NAS>/project/asset/task/animation_v001.ma"
+
+        Args:
+            filepath (str): Full file path where root should be replaced.
+            template (str): Optional template for environment key. Must
+                have one index format key.
+                Default value if not entered: "${}"
+
+        Returns:
+            str: Path where root is replaced with environment root key.
+
+        Raise:
+            ValueError: When project's roots were not found in entered path.
+        """
+        success, rootless_path = self.find_root_template_from_path(filepath)
+        if not success:
+            raise ValueError(
+                "{}: Project's roots were not found in path: {}".format(
+                    self.project_name, filepath
+                )
+            )
+
+        data = self.root_environmets_fill_data(template)
+        return rootless_path.format(**data)
+
 
 class TemplateMissingKey(Exception):
     """Exception for cases when key does not exist in Anatomy."""

--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -142,6 +142,15 @@ class Anatomy:
         """Return PYPE_PROJECT_ROOT_* environments for current project."""
         return self._roots_obj.root_environments()
 
+    def root_environmets_fill_data(self, template=None):
+        """Environment variable values in dictionary for rootless path.
+
+        Args:
+            template (str): Template for environment variable key fill.
+                By default is set to `"${}"`.
+        """
+        return self.roots_obj.root_environmets_fill_data(template)
+
     def find_root_template_from_path(self, *args, **kwargs):
         """Wrapper for Roots `find_root_template_from_path`."""
         return self.roots_obj.find_root_template_from_path(*args, **kwargs)
@@ -1532,6 +1541,41 @@ class Roots:
             _keys = list(keys)
             _keys.append(_key)
             output.update(self._root_environments(_keys, _value))
+        return output
+
+    def root_environmets_fill_data(self, template=None):
+        """Environment variable values in dictionary for rootless path.
+
+        Args:
+            template (str): Template for environment variable key fill.
+                By default is set to `"${}"`.
+        """
+        if template is None:
+            template = "${}"
+        return self._root_environmets_fill_data(template)
+
+    def _root_environmets_fill_data(self, template, keys=None, roots=None):
+        if keys is None and roots is None:
+            return {
+                "root": self._root_environmets_fill_data(
+                    template, [], self.roots
+                )
+            }
+
+        if isinstance(roots, RootItem):
+            key_items = [Roots.env_prefix]
+            for _key in keys:
+                key_items.append(_key.upper())
+            key = "_".join(key_items)
+            return template.format(key)
+
+        output = {}
+        for key, value in roots.items():
+            _keys = list(keys)
+            _keys.append(key)
+            output[key] = self._root_environmets_fill_data(
+                template, _keys, value
+            )
         return output
 
     @property

--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -139,7 +139,7 @@ class Anatomy:
         return self._roots_obj
 
     def root_environments(self):
-        """Return PYPE_ROOT_* environments for current project in dict."""
+        """Return PYPE_PROJECT_ROOT_* environments for current project."""
         return self._roots_obj.root_environments()
 
     def find_root_template_from_path(self, *args, **kwargs):
@@ -155,7 +155,7 @@ class Anatomy:
         return self.roots_obj.all_root_paths()
 
     def set_root_environments(self):
-        """Set PYPE_ROOT_* environments for current project."""
+        """Set PYPE_PROJECT_ROOT_* environments for current project."""
         self._roots_obj.set_root_environments()
 
     def root_names(self):
@@ -1351,7 +1351,7 @@ class Roots:
             `keep_updated` are ignored and are used parent's values.
     """
 
-    env_prefix = "PYPE_ROOT"
+    env_prefix = "PYPE_PROJECT_ROOT"
     roots_filename = "roots.json"
 
     def __init__(
@@ -1468,7 +1468,7 @@ class Roots:
     def root_environments(self):
         """Use root keys to create unique keys for environment variables.
 
-        Concatenates prefix "PYPE_ROOT" with root keys to create unique keys.
+        Concatenates prefix "PYPE_PROJECT_ROOT" with root keys to create unique keys.
 
         Returns:
             dict: Result is `{(str): (str)}` dicitonary where key represents
@@ -1490,13 +1490,13 @@ class Roots:
 
             Result on windows platform::
                 {
-                    "PYPE_ROOT_WORK": "P:/projects/work",
-                    "PYPE_ROOT_PUBLISH": "P:/projects/publish"
+                    "PYPE_PROJECT_ROOT_WORK": "P:/projects/work",
+                    "PYPE_PROJECT_ROOT_PUBLISH": "P:/projects/publish"
                 }
 
             Short example when multiroot is not used::
                 {
-                    "PYPE_ROOT": "P:/projects"
+                    "PYPE_PROJECT_ROOT": "P:/projects"
                 }
         """
         return self._root_environments()


### PR DESCRIPTION
## Issue
- anatomy use `PYPE_ROOT` as base for environment variable key
- anatomy does not have ability to fill or replace environment variable key in template or in path

## Changes
- `Roots` has implemented new method  `root_environmets_fill_data` which is also available from Anatomy object
    - method returns data for filling root in template with environment keys
    - result of method
    ```
    # Singleroot
    {
        "root": "PYPE_PROJECT_ROOT"
    }
    # Multiroot
    {
        "root": {
            "nas": "PYPE_PROJECT_ROOT_NAS",
            "render": "PYPE_PROJECT_ROOT_RENDER"
        }
    }
    ```
- implemented function `replace_root_with_env_key` which replace root in entered path with environment key
    - arguments `filepath` and optional `template`
    - `filepath` - Full path to file (or folder) where environment variable key should be used
    - `template` optional - Template of environment variable key by default is set to `"${}"`
         - template defines how output will look like

### Example of `replace_root_with_env_key`
**Project roots:**
```
{
    "nas": {
        "windows": P:/projects",
        ...
    }
    ...
}
```

**Example code:**
```Python
anatomy = Anatomy()

filepath = "P:/projects/project/asset/task/animation_v001.ma"
result_1 = anatomy.replace_root_with_env_key(filepath)
print("Result 1", result_1)
>>> "$PYPE_PROJECT_ROOT_NAS/project/asset/task/animation_v001.ma"

template = "<{}>"
result_2 = anatomy.replace_root_with_env_key(filepath, template)
print("Result 2", result_2)
>>> "<PYPE_PROJECT_ROOT_NAS>/project/asset/task/animation_v001.ma"
```