### PR TITLE
Anatomy fill custom root

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -256,6 +256,24 @@ class Anatomy:
         # NOTE does not care if there are different keys than "root"
         return template_path.format(**{"root": self.roots})
 
+    def fill_root_with_path(self, rootless_path, root_path):
+        """Fill rootless template path with passed path.
+
+        This is helper to fill root with different directory no matter if
+        is single or multiroot.
+
+        Args:
+            rootless_path (str): Path without filled "root" key. Example:
+                "{root[work]}/MyProject/..."
+            root_path (str): What should replace root key in `rootless_path`.
+        """
+        output = str(rootless_path)
+        for group in re.findall(self.root_key_regex, rootless_path):
+            replacement = "{" + group + "}"
+            output = output.replace(replacement, root_path)
+
+        return output
+
     def replace_root_with_env_key(self, filepath, template=None):
         """Replace root of path with environment key.
 

--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -257,15 +257,21 @@ class Anatomy:
         return template_path.format(**{"root": self.roots})
 
     def fill_root_with_path(self, rootless_path, root_path):
-        """Fill rootless template path with passed path.
+        """Fill path without filled "root" key with passed path.
 
-        This is helper to fill root with different directory no matter if
-        is single or multiroot.
+        This is helper to fill root with different directory path than anatomy
+        has defined no matter if is single or multiroot.
+
+        Output path is same as input path if `rootless_path` does not contain
+        unfilled root key.
 
         Args:
             rootless_path (str): Path without filled "root" key. Example:
                 "{root[work]}/MyProject/..."
             root_path (str): What should replace root key in `rootless_path`.
+
+        Returns:
+            str: Path with filled root.
         """
         output = str(rootless_path)
         for group in re.findall(self.root_key_regex, rootless_path):

--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -256,7 +256,8 @@ class Anatomy:
         # NOTE does not care if there are different keys than "root"
         return template_path.format(**{"root": self.roots})
 
-    def fill_root_with_path(self, rootless_path, root_path):
+    @classmethod
+    def fill_root_with_path(cls, rootless_path, root_path):
         """Fill path without filled "root" key with passed path.
 
         This is helper to fill root with different directory path than anatomy
@@ -274,7 +275,7 @@ class Anatomy:
             str: Path with filled root.
         """
         output = str(rootless_path)
-        for group in re.findall(self.root_key_regex, rootless_path):
+        for group in re.findall(cls.root_key_regex, rootless_path):
             replacement = "{" + group + "}"
             output = output.replace(replacement, root_path)
 

--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -1411,6 +1411,10 @@ class RootItem:
         root_paths = list(self.cleaned_data.values())
         mod_path = self.clean_path(path)
         for root_path in root_paths:
+            # Skip empty paths
+            if not root_path:
+                continue
+
             if mod_path.startswith(root_path):
                 result = True
                 replacement = "{" + self.full_key() + "}"


### PR DESCRIPTION
## Issue
1.) Anatomy does not allow to fill different roots than has defined in `roots.json`, which is rule by design of anatomy, but it may be helpfull to fill rootless path with custom root.
2.) Another issue is that `find_root_template_from_path` does not check if root value is filled with nonempty string so may return invalid values.

## Changes
1.) Implemented `fill_root_with_path` class method which fill root key in rootless path with entered directory path, no matter if is single or multiroot. Single and multiroot is only reason why this helper method is required.
2.) `find_root_template_from_path` check root values if are empty.
