### PR TITLE
Fix root return in Anatomy.

### DIFF
--- a/pypeapp/lib/anatomy.py
+++ b/pypeapp/lib/anatomy.py
@@ -199,7 +199,7 @@ class Anatomy:
         """Returns value of root key from template."""
         root_templates = []
         for group in re.findall(self.root_key_regex, template):
-            root_templates.append(group)
+            root_templates.append("{" + group + "}")
 
         if not root_templates:
             return None


### PR DESCRIPTION
This methods formatting is wrong; https://github.com/pypeclub/pype-setup/blob/main/pypeapp/lib/anatomy.py#L198-L207
The `root_templates` list items does not contain curly brackets so the formatting doesnt actually substitute the `root` keyword.