### PR TITLE
Report Json errors of project specific configurations

### DIFF
--- a/pypeapp/lib/config.py
+++ b/pypeapp/lib/config.py
@@ -90,7 +90,7 @@ def get_datetime_data(datetime_obj=None):
     }
 
 
-def load_json(fpath, first_run=False):
+def load_json(fpath, report_errors=True):
     # Load json data
     with open(fpath, "r") as opened_file:
         lines = opened_file.read().splitlines()
@@ -114,12 +114,12 @@ def load_json(fpath, first_run=False):
     standard_json = standard_json.replace(",]", "]")
     standard_json = standard_json.replace(",}", "}")
 
-    if extra_comma and first_run:
+    if extra_comma and report_errors:
         log.error("Extra comma in json file: \"{}\"".format(fpath))
 
     # return empty dict if file is empty
     if standard_json == "":
-        if first_run:
+        if report_errors:
             log.error("Empty json file: \"{}\"".format(fpath))
         return {}
 
@@ -129,7 +129,7 @@ def load_json(fpath, first_run=False):
 
     except JsonError:
         # Return empty dict if it is first time that decode error happened
-        if not first_run:
+        if not report_errors:
             return {}
 
     # Repreduce the exact same exception but traceback contains better
@@ -147,7 +147,7 @@ def load_json(fpath, first_run=False):
     return {}
 
 
-def collect_json_from_path(input_path, first_run=False):
+def collect_json_from_path(input_path, report_errors=True):
     r""" Json collector
     iterate through all subfolders and json files in *input_path*
 
@@ -169,17 +169,17 @@ def collect_json_from_path(input_path, first_run=False):
         for file in os.listdir(input_path):
             full_path = os.path.sep.join([input_path, file])
             if os.path.isdir(full_path):
-                loaded = collect_json_from_path(full_path, first_run)
+                loaded = collect_json_from_path(full_path, report_errors)
                 if loaded:
                     output[file] = loaded
             else:
                 basename, ext = os.path.splitext(os.path.basename(file))
                 if ext == '.json':
-                    output[basename] = load_json(full_path, first_run)
+                    output[basename] = load_json(full_path, report_errors)
     else:
         basename, ext = os.path.splitext(os.path.basename(input_path))
         if ext == '.json':
-            output = load_json(input_path, first_run)
+            output = load_json(input_path, report_errors)
 
     return output
 

--- a/pypeapp/lib/config.py
+++ b/pypeapp/lib/config.py
@@ -14,6 +14,10 @@ else:
     JsonError = ValueError
 
 
+# Keep track of project from 'get_presets' last call
+global_last_project = None
+
+
 def get_datetime_data(datetime_obj=None):
     """Returns current datetime data as dictionary.
 
@@ -214,6 +218,9 @@ def get_presets(project=None, first_run=False):
     if not project:
         project = os.environ.get('AVALON_PROJECT', None)
 
+    global global_last_project
+    if first_run:
+        global_last_project = None
     if not project:
         return default_data
 
@@ -230,6 +237,9 @@ def get_presets(project=None, first_run=False):
             project, project_config_path
         ))
         return default_data
+    if project != global_last_project:
+        first_run = True
+        global_last_project = project
     project_data = collect_json_from_path(project_config_path, first_run)
 
     return update_dict(default_data, project_data)


### PR DESCRIPTION
# Issue

When using project specific configurations (with overridden presets), errors present in the Json files are not reported in Pype logs and thus difficult to detect.

This is because when initially loading the presets (during the Pype Tray loading), the projects specific configurations are not loaded (only the default configuration and potentially the initial project's if 'AVALON_PROJECT' is defined).
When later loading a project configuration, the 'first run' is not set anymore, and thus Json errors logs are ignored.


# To reproduce

The issue can easily be reproduced by having an invalid Json file in the project's configuration, and executing an action that loads the preset.

A quick example by following these steps:
- Edit (or create) the ftrack project defaults file in the project's configuration directory (NOT in the default configuration)
    '<PROJECT_CONFIG>/presets/ftrack/project_defaults.json'
- Add some invalid Json content to the file
    E.g.:
    ```
    # invalid json
    ...
    ```
- Start the Pype Tray
- In ftrack, select the project and start the action "Prepare Project" on the project
    Wait for the action's interface to display, then close it (don't execute the action)

Looking at the Pype logs, no error has been logged, hiding the fact that the configuration file was invalid and thus ignored.


# Proposed solution

To fix this, 'get_presets' can determine if the current project has changed since the last call, in which case it is considered as a 'first run', and Json errors will be reported.
This will however report errors again if we come back to a previously used project, but it is better than not having the errors reported at all.


