### PR TITLE
Acre: fix appending to existing related paths

### DIFF
--- a/vendor/python/acre/acre/lib.py
+++ b/vendor/python/acre/acre/lib.py
@@ -83,7 +83,6 @@ def topological_sort(dependency_pairs):
 def append_path(self, key, path):
     """Append *path* to *key* in *self*."""
     try:
-        if path not in self[key]:
-            self[key] = os.pathsep.join([self[key], str(path)])
+        self[key] = os.pathsep.join([self[key], str(path)])
     except KeyError:
         self[key] = str(path)


### PR DESCRIPTION
Bug in acre preventing adding of path that were related - `/foo/bar/baz;/foo/bar` only `/foo/bar/baz`  survived.